### PR TITLE
ci: Implement an auto-build pipeline

### DIFF
--- a/.github/workflows/autoversion-main.yml
+++ b/.github/workflows/autoversion-main.yml
@@ -46,3 +46,12 @@ jobs:
           cmd: release
       - name: Publish
         run: git push --follow-tags origin main
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body_path: CHANGELOG.md


### PR DESCRIPTION
Use a generic Github action to create a release after auto-versioning.
Set the release body to CHANGELOG.md and see how that works.

Resolves #3